### PR TITLE
Move duplicate amount tracking to backend

### DIFF
--- a/XiaoYang/internal/cache/dungeonStats.go
+++ b/XiaoYang/internal/cache/dungeonStats.go
@@ -1,0 +1,157 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/go-dev-frame/sponge/pkg/cache"
+	"github.com/go-dev-frame/sponge/pkg/encoding"
+	"github.com/go-dev-frame/sponge/pkg/utils"
+
+	"XiaoYang/internal/database"
+	"XiaoYang/internal/model"
+)
+
+const (
+	// cache prefix key, must end with a colon
+	dungeonStatsCachePrefixKey = "dungeonStats:"
+	// DungeonStatsExpireTime expire time
+	DungeonStatsExpireTime = 5 * time.Minute
+)
+
+var _ DungeonStatsCache = (*dungeonStatsCache)(nil)
+
+// DungeonStatsCache cache interface
+type DungeonStatsCache interface {
+	Set(ctx context.Context, id uint64, data *model.DungeonStats, duration time.Duration) error
+	Get(ctx context.Context, id uint64) (*model.DungeonStats, error)
+	MultiGet(ctx context.Context, ids []uint64) (map[uint64]*model.DungeonStats, error)
+	MultiSet(ctx context.Context, data []*model.DungeonStats, duration time.Duration) error
+	Del(ctx context.Context, id uint64) error
+	SetPlaceholder(ctx context.Context, id uint64) error
+	IsPlaceholderErr(err error) bool
+}
+
+// dungeonStatsCache define a cache struct
+type dungeonStatsCache struct {
+	cache cache.Cache
+}
+
+// NewDungeonStatsCache new a cache
+func NewDungeonStatsCache(cacheType *database.CacheType) DungeonStatsCache {
+	jsonEncoding := encoding.JSONEncoding{}
+	cachePrefix := ""
+
+	cType := strings.ToLower(cacheType.CType)
+	switch cType {
+	case "redis":
+		c := cache.NewRedisCache(cacheType.Rdb, cachePrefix, jsonEncoding, func() interface{} {
+			return &model.DungeonStats{}
+		})
+		return &dungeonStatsCache{cache: c}
+	case "memory":
+		c := cache.NewMemoryCache(cachePrefix, jsonEncoding, func() interface{} {
+			return &model.DungeonStats{}
+		})
+		return &dungeonStatsCache{cache: c}
+	}
+
+	return nil // no cache
+}
+
+// GetDungeonStatsCacheKey cache key
+func (c *dungeonStatsCache) GetDungeonStatsCacheKey(id uint64) string {
+	return dungeonStatsCachePrefixKey + utils.Uint64ToStr(id)
+}
+
+// Set write to cache
+func (c *dungeonStatsCache) Set(ctx context.Context, id uint64, data *model.DungeonStats, duration time.Duration) error {
+	if data == nil || id == 0 {
+		return nil
+	}
+	cacheKey := c.GetDungeonStatsCacheKey(id)
+	err := c.cache.Set(ctx, cacheKey, data, duration)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Get cache value
+func (c *dungeonStatsCache) Get(ctx context.Context, id uint64) (*model.DungeonStats, error) {
+	var data *model.DungeonStats
+	cacheKey := c.GetDungeonStatsCacheKey(id)
+	err := c.cache.Get(ctx, cacheKey, &data)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// MultiSet multiple set cache
+func (c *dungeonStatsCache) MultiSet(ctx context.Context, data []*model.DungeonStats, duration time.Duration) error {
+	valMap := make(map[string]interface{})
+	for _, v := range data {
+		cacheKey := c.GetDungeonStatsCacheKey(v.ID)
+		valMap[cacheKey] = v
+	}
+
+	err := c.cache.MultiSet(ctx, valMap, duration)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// MultiGet multiple get cache
+func (c *dungeonStatsCache) MultiGet(ctx context.Context, ids []uint64) (map[uint64]*model.DungeonStats, error) {
+	var keys []string
+	for _, v := range ids {
+		cacheKey := c.GetDungeonStatsCacheKey(v)
+		keys = append(keys, cacheKey)
+	}
+
+	itemMap := make(map[string]*model.DungeonStats)
+	err := c.cache.MultiGet(ctx, keys, itemMap)
+	if err != nil {
+		return nil, err
+	}
+
+	retMap := make(map[uint64]*model.DungeonStats)
+	for _, id := range ids {
+		val, ok := itemMap[c.GetDungeonStatsCacheKey(id)]
+		if ok {
+			retMap[id] = val
+		}
+	}
+
+	return retMap, nil
+}
+
+// Del delete cache
+func (c *dungeonStatsCache) Del(ctx context.Context, id uint64) error {
+	cacheKey := c.GetDungeonStatsCacheKey(id)
+	err := c.cache.Del(ctx, cacheKey)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetPlaceholder set placeholder
+func (c *dungeonStatsCache) SetPlaceholder(ctx context.Context, id uint64) error {
+	cacheKey := c.GetDungeonStatsCacheKey(id)
+	err := c.cache.Set(ctx, cacheKey, &cache.Placeholder{}, time.Hour)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// IsPlaceholderErr check if error is placeholder error
+func (c *dungeonStatsCache) IsPlaceholderErr(err error) bool {
+	return errors.Is(err, cache.ErrPlaceholder)
+}

--- a/XiaoYang/internal/dao/dungeonStats.go
+++ b/XiaoYang/internal/dao/dungeonStats.go
@@ -1,0 +1,289 @@
+package dao
+
+import (
+	"context"
+	"errors"
+
+	"golang.org/x/sync/singleflight"
+	"gorm.io/gorm"
+
+	"github.com/go-dev-frame/sponge/pkg/logger"
+	"github.com/go-dev-frame/sponge/pkg/sgorm/query"
+	"github.com/go-dev-frame/sponge/pkg/utils"
+
+	"XiaoYang/internal/cache"
+	"XiaoYang/internal/database"
+	"XiaoYang/internal/model"
+)
+
+var _ DungeonStatsDao = (*dungeonStatsDao)(nil)
+
+// DungeonStatsDao defining the dao interface
+type DungeonStatsDao interface {
+	Create(ctx context.Context, table *model.DungeonStats) error
+	DeleteByID(ctx context.Context, id uint64) error
+	UpdateByID(ctx context.Context, table *model.DungeonStats) error
+	GetByID(ctx context.Context, id uint64) (*model.DungeonStats, error)
+	GetByGuildAndDungeon(ctx context.Context, guildID int, dungeonName string) (*model.DungeonStats, error)
+	GetByColumns(ctx context.Context, params *query.Params) ([]*model.DungeonStats, int64, error)
+	UpsertStats(ctx context.Context, stats *model.DungeonStats) error
+
+	CreateByTx(ctx context.Context, tx *gorm.DB, table *model.DungeonStats) (uint64, error)
+	DeleteByTx(ctx context.Context, tx *gorm.DB, id uint64) error
+	UpdateByTx(ctx context.Context, tx *gorm.DB, table *model.DungeonStats) error
+	UpsertStatsByTx(ctx context.Context, tx *gorm.DB, stats *model.DungeonStats) error
+}
+
+type dungeonStatsDao struct {
+	db    *gorm.DB
+	cache cache.DungeonStatsCache // if nil, the cache is not used.
+	sfg   *singleflight.Group     // if cache is nil, the sfg is not used.
+}
+
+// NewDungeonStatsDao creating the dao interface
+func NewDungeonStatsDao(db *gorm.DB, xCache cache.DungeonStatsCache) DungeonStatsDao {
+	if xCache == nil {
+		return &dungeonStatsDao{db: db}
+	}
+	return &dungeonStatsDao{
+		db:    db,
+		cache: xCache,
+		sfg:   new(singleflight.Group),
+	}
+}
+
+func (d *dungeonStatsDao) deleteCache(ctx context.Context, id uint64) error {
+	if d.cache != nil {
+		return d.cache.Del(ctx, id)
+	}
+	return nil
+}
+
+// Create a record, insert the record and the id value is written back to the table
+func (d *dungeonStatsDao) Create(ctx context.Context, table *model.DungeonStats) error {
+	return d.db.WithContext(ctx).Create(table).Error
+}
+
+// DeleteByID delete a record by id
+func (d *dungeonStatsDao) DeleteByID(ctx context.Context, id uint64) error {
+	err := d.db.WithContext(ctx).Where("id = ?", id).Delete(&model.DungeonStats{}).Error
+	if err != nil {
+		return err
+	}
+
+	// delete cache
+	_ = d.deleteCache(ctx, id)
+
+	return nil
+}
+
+// UpdateByID update a record by id
+func (d *dungeonStatsDao) UpdateByID(ctx context.Context, table *model.DungeonStats) error {
+	err := d.updateDataByID(ctx, d.db, table)
+
+	// delete cache
+	_ = d.deleteCache(ctx, table.ID)
+
+	return err
+}
+
+func (d *dungeonStatsDao) updateDataByID(ctx context.Context, db *gorm.DB, table *model.DungeonStats) error {
+	if table.ID < 1 {
+		return errors.New("id cannot be 0")
+	}
+
+	update := map[string]interface{}{}
+
+	if table.GuildID != 0 {
+		update["guild_id"] = table.GuildID
+	}
+	if table.DungeonName != "" {
+		update["dungeon_name"] = table.DungeonName
+	}
+	update["total_count"] = table.TotalCount
+	update["min_salary"] = table.MinSalary
+	update["max_salary"] = table.MaxSalary
+	update["avg_salary"] = table.AvgSalary
+	update["min_per_person_salary"] = table.MinPerPersonSalary
+	update["max_per_person_salary"] = table.MaxPerPersonSalary
+	update["avg_per_person_salary"] = table.AvgPerPersonSalary
+
+	if table.MinSalaryTeamID != nil {
+		update["min_salary_team_id"] = table.MinSalaryTeamID
+	}
+	if table.MaxSalaryTeamID != nil {
+		update["max_salary_team_id"] = table.MaxSalaryTeamID
+	}
+
+	if table.CreateTime != nil && !table.CreateTime.IsZero() {
+		update["create_time"] = table.CreateTime
+	}
+	if table.UpdateTime != nil && !table.UpdateTime.IsZero() {
+		update["update_time"] = table.UpdateTime
+	}
+
+	return db.WithContext(ctx).Model(table).Updates(update).Error
+}
+
+// GetByID get a record by id
+func (d *dungeonStatsDao) GetByID(ctx context.Context, id uint64) (*model.DungeonStats, error) {
+	// no cache
+	if d.cache == nil {
+		record := &model.DungeonStats{}
+		err := d.db.WithContext(ctx).Where("id = ?", id).First(record).Error
+		return record, err
+	}
+
+	// get from cache
+	record, err := d.cache.Get(ctx, id)
+	if err == nil {
+		return record, nil
+	}
+
+	// get from database
+	if errors.Is(err, database.ErrCacheNotFound) {
+		// for the same id, prevent high concurrent simultaneous access to database
+		val, err, _ := d.sfg.Do(utils.Uint64ToStr(id), func() (interface{}, error) { //nolint
+			table := &model.DungeonStats{}
+			err = d.db.WithContext(ctx).Where("id = ?", id).First(table).Error
+			if err != nil {
+				if errors.Is(err, database.ErrRecordNotFound) {
+					// set placeholder cache to prevent cache penetration, default expiration time 10 minutes
+					if err = d.cache.SetPlaceholder(ctx, id); err != nil {
+						logger.Warn("cache.SetPlaceholder error", logger.Err(err), logger.Any("id", id))
+					}
+					return nil, database.ErrRecordNotFound
+				}
+				return nil, err
+			}
+			// set cache
+			if err = d.cache.Set(ctx, id, table, cache.DungeonStatsExpireTime); err != nil {
+				logger.Warn("cache.Set error", logger.Err(err), logger.Any("id", id))
+			}
+			return table, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		table, ok := val.(*model.DungeonStats)
+		if !ok {
+			return nil, database.ErrRecordNotFound
+		}
+		return table, nil
+	}
+
+	if d.cache.IsPlaceholderErr(err) {
+		return nil, database.ErrRecordNotFound
+	}
+
+	return nil, err
+}
+
+// GetByGuildAndDungeon get a record by guild_id and dungeon_name
+func (d *dungeonStatsDao) GetByGuildAndDungeon(ctx context.Context, guildID int, dungeonName string) (*model.DungeonStats, error) {
+	record := &model.DungeonStats{}
+	err := d.db.WithContext(ctx).Where("guild_id = ? AND dungeon_name = ?", guildID, dungeonName).First(record).Error
+	if err != nil {
+		return nil, err
+	}
+	return record, nil
+}
+
+// GetByColumns get paging records by column information
+func (d *dungeonStatsDao) GetByColumns(ctx context.Context, params *query.Params) ([]*model.DungeonStats, int64, error) {
+	queryStr, args, err := params.ConvertToGormConditions()
+	if err != nil {
+		return nil, 0, errors.New("query params error: " + err.Error())
+	}
+
+	var total int64
+	if params.Sort != "ignore count" { // determine if count is required
+		err = d.db.WithContext(ctx).Model(&model.DungeonStats{}).Where(queryStr, args...).Count(&total).Error
+		if err != nil {
+			return nil, 0, err
+		}
+		if total == 0 {
+			return nil, total, nil
+		}
+	}
+
+	records := []*model.DungeonStats{}
+	order, limit, offset := params.ConvertToPage()
+	err = d.db.WithContext(ctx).Order(order).Limit(limit).Offset(offset).Where(queryStr, args...).Find(&records).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return records, total, err
+}
+
+// UpsertStats upsert (insert or update) dungeon statistics
+func (d *dungeonStatsDao) UpsertStats(ctx context.Context, stats *model.DungeonStats) error {
+	return d.UpsertStatsByTx(ctx, d.db, stats)
+}
+
+// CreateByTx create a record in the database using the provided transaction
+func (d *dungeonStatsDao) CreateByTx(ctx context.Context, tx *gorm.DB, table *model.DungeonStats) (uint64, error) {
+	err := tx.WithContext(ctx).Create(table).Error
+	return table.ID, err
+}
+
+// DeleteByTx delete a record by id in the database using the provided transaction
+func (d *dungeonStatsDao) DeleteByTx(ctx context.Context, tx *gorm.DB, id uint64) error {
+	err := tx.WithContext(ctx).Where("id = ?", id).Delete(&model.DungeonStats{}).Error
+	if err != nil {
+		return err
+	}
+
+	// delete cache
+	_ = d.deleteCache(ctx, id)
+
+	return nil
+}
+
+// UpdateByTx update a record by id in the database using the provided transaction
+func (d *dungeonStatsDao) UpdateByTx(ctx context.Context, tx *gorm.DB, table *model.DungeonStats) error {
+	err := d.updateDataByID(ctx, tx, table)
+
+	// delete cache
+	_ = d.deleteCache(ctx, table.ID)
+
+	return err
+}
+
+// UpsertStatsByTx upsert dungeon statistics in a transaction
+func (d *dungeonStatsDao) UpsertStatsByTx(ctx context.Context, tx *gorm.DB, stats *model.DungeonStats) error {
+	// PostgreSQL UPSERT using ON CONFLICT
+	err := tx.WithContext(ctx).Exec(`
+		INSERT INTO dungeon_stats (
+			guild_id, dungeon_name, total_count, min_salary, max_salary, avg_salary,
+			min_per_person_salary, max_per_person_salary, avg_per_person_salary,
+			min_salary_team_id, max_salary_team_id, update_time
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
+		ON CONFLICT (guild_id, dungeon_name)
+		DO UPDATE SET
+			total_count = EXCLUDED.total_count,
+			min_salary = EXCLUDED.min_salary,
+			max_salary = EXCLUDED.max_salary,
+			avg_salary = EXCLUDED.avg_salary,
+			min_per_person_salary = EXCLUDED.min_per_person_salary,
+			max_per_person_salary = EXCLUDED.max_per_person_salary,
+			avg_per_person_salary = EXCLUDED.avg_per_person_salary,
+			min_salary_team_id = EXCLUDED.min_salary_team_id,
+			max_salary_team_id = EXCLUDED.max_salary_team_id,
+			update_time = NOW()
+	`, stats.GuildID, stats.DungeonName, stats.TotalCount, stats.MinSalary, stats.MaxSalary, stats.AvgSalary,
+		stats.MinPerPersonSalary, stats.MaxPerPersonSalary, stats.AvgPerPersonSalary,
+		stats.MinSalaryTeamID, stats.MaxSalaryTeamID).Error
+
+	if err != nil {
+		return err
+	}
+
+	// delete cache if exists
+	if stats.ID > 0 {
+		_ = d.deleteCache(ctx, stats.ID)
+	}
+
+	return nil
+}

--- a/XiaoYang/internal/model/dungeonStats.go
+++ b/XiaoYang/internal/model/dungeonStats.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"time"
+)
+
+// DungeonStats 副本统计数据
+type DungeonStats struct {
+	ID                   uint64     `gorm:"column:id;type:int4;primary_key" json:"id"`                                                 // 统计ID
+	GuildID              int        `gorm:"column:guild_id;type:int4;not null" json:"guildID"`                                         // 群组ID
+	DungeonName          string     `gorm:"column:dungeon_name;type:varchar(50);not null" json:"dungeonName"`                          // 副本名称
+	TotalCount           int        `gorm:"column:total_count;type:int4;not null;default:0" json:"totalCount"`                         // 总记录数
+	MinSalary            int        `gorm:"column:min_salary;type:int4;not null;default:0" json:"minSalary"`                           // 最低总金团
+	MaxSalary            int        `gorm:"column:max_salary;type:int4;not null;default:0" json:"maxSalary"`                           // 最高总金团
+	AvgSalary            float64    `gorm:"column:avg_salary;type:decimal(10,2);not null;default:0" json:"avgSalary"`                  // 平均总金团
+	MinPerPersonSalary   int        `gorm:"column:min_per_person_salary;type:int4;not null;default:0" json:"minPerPersonSalary"`       // 最低人均金团
+	MaxPerPersonSalary   int        `gorm:"column:max_per_person_salary;type:int4;not null;default:0" json:"maxPerPersonSalary"`       // 最高人均金团
+	AvgPerPersonSalary   float64    `gorm:"column:avg_per_person_salary;type:decimal(10,2);not null;default:0" json:"avgPerPersonSalary"` // 平均人均金团
+	MinSalaryTeamID      *int       `gorm:"column:min_salary_team_id;type:int4" json:"minSalaryTeamID"`                                // 最低金团对应的团队ID
+	MaxSalaryTeamID      *int       `gorm:"column:max_salary_team_id;type:int4" json:"maxSalaryTeamID"`                                // 最高金团对应的团队ID
+	CreateTime           *time.Time `gorm:"column:create_time;type:timestamp" json:"createTime"`                                       // 创建时间
+	UpdateTime           *time.Time `gorm:"column:update_time;type:timestamp" json:"updateTime"`                                       // 更新时间
+}

--- a/XiaoYang/internal/service/dungeonStatsService.go
+++ b/XiaoYang/internal/service/dungeonStatsService.go
@@ -1,0 +1,234 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/go-dev-frame/sponge/pkg/logger"
+	"github.com/go-dev-frame/sponge/pkg/sgorm/query"
+
+	"XiaoYang/internal/dao"
+	"XiaoYang/internal/database"
+	"XiaoYang/internal/model"
+)
+
+// DungeonStatsService 副本统计服务
+type DungeonStatsService struct {
+	teamsDao        dao.TeamsDao
+	dungeonStatsDao dao.DungeonStatsDao
+	db              *gorm.DB
+}
+
+// NewDungeonStatsService 创建副本统计服务
+func NewDungeonStatsService(teamsDao dao.TeamsDao, dungeonStatsDao dao.DungeonStatsDao) *DungeonStatsService {
+	return &DungeonStatsService{
+		teamsDao:        teamsDao,
+		dungeonStatsDao: dungeonStatsDao,
+		db:              database.GetDB(),
+	}
+}
+
+// SummaryData 团队总结数据结构
+type SummaryData struct {
+	Salary          int      `json:"salary"`
+	PerPersonSalary int      `json:"perPersonSalary"`
+	SpecialDrops    []string `json:"specialDrops"`
+	Blacklist       string   `json:"blacklist"`
+}
+
+// UpdateStatsForTeam 更新指定团队对应副本的统计数据
+func (s *DungeonStatsService) UpdateStatsForTeam(ctx context.Context, guildID int, dungeonName string) error {
+	// 使用事务确保数据一致性
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		return s.updateStatsInTx(ctx, tx, guildID, dungeonName)
+	})
+}
+
+// updateStatsInTx 在事务中更新统计数据
+func (s *DungeonStatsService) updateStatsInTx(ctx context.Context, tx *gorm.DB, guildID int, dungeonName string) error {
+	// 查询该公会该副本的所有已关闭团队
+	params := &query.Params{
+		Page:  0,
+		Limit: 10000, // 设置一个较大的值以获取所有记录
+		Columns: []query.Column{
+			{
+				Name:  "guild_id",
+				Exp:   "=",
+				Value: guildID,
+			},
+			{
+				Name:  "dungeons",
+				Exp:   "=",
+				Value: dungeonName,
+			},
+			{
+				Name:     "close_time",
+				Exp:      "isnotnull",
+				Value:    "",
+				Logic:    "and",
+			},
+		},
+		Sort: "ignore count", // 不需要count
+	}
+
+	teams, _, err := s.teamsDao.GetByColumns(ctx, params)
+	if err != nil {
+		logger.Error("GetByColumns error", logger.Err(err))
+		return err
+	}
+
+	// 如果没有团队记录，删除统计数据（如果存在）
+	if len(teams) == 0 {
+		// 尝试删除可能存在的统计记录
+		stats, err := s.dungeonStatsDao.GetByGuildAndDungeon(ctx, guildID, dungeonName)
+		if err == nil && stats != nil {
+			return s.dungeonStatsDao.DeleteByTx(ctx, tx, stats.ID)
+		}
+		return nil
+	}
+
+	// 计算统计数据
+	var (
+		totalCount           = 0
+		minSalary            = int(^uint(0) >> 1) // 最大整数
+		maxSalary            = 0
+		totalSalary          = int64(0)
+		minPerPersonSalary   = int(^uint(0) >> 1)
+		maxPerPersonSalary   = 0
+		totalPerPersonSalary = int64(0)
+		minSalaryTeamID      *int
+		maxSalaryTeamID      *int
+	)
+
+	for _, team := range teams {
+		if team.Summary == nil {
+			continue
+		}
+
+		var summary SummaryData
+		err := json.Unmarshal([]byte(team.Summary.String()), &summary)
+		if err != nil {
+			logger.Warn("Failed to unmarshal summary", logger.Err(err), logger.Any("teamId", team.ID))
+			continue
+		}
+
+		// 只统计有效的金额记录
+		if summary.Salary <= 0 && summary.PerPersonSalary <= 0 {
+			continue
+		}
+
+		totalCount++
+		salary := summary.Salary
+		perPersonSalary := summary.PerPersonSalary
+
+		// 更新总金团统计
+		if salary > 0 {
+			totalSalary += int64(salary)
+			if salary < minSalary {
+				minSalary = salary
+				teamID := int(team.ID)
+				minSalaryTeamID = &teamID
+			}
+			if salary > maxSalary {
+				maxSalary = salary
+				teamID := int(team.ID)
+				maxSalaryTeamID = &teamID
+			}
+		}
+
+		// 更新人均金团统计
+		if perPersonSalary > 0 {
+			totalPerPersonSalary += int64(perPersonSalary)
+			if perPersonSalary < minPerPersonSalary {
+				minPerPersonSalary = perPersonSalary
+			}
+			if perPersonSalary > maxPerPersonSalary {
+				maxPerPersonSalary = perPersonSalary
+			}
+		}
+	}
+
+	// 如果没有有效的统计数据，返回
+	if totalCount == 0 {
+		return nil
+	}
+
+	// 计算平均值
+	avgSalary := float64(totalSalary) / float64(totalCount)
+	avgPerPersonSalary := float64(totalPerPersonSalary) / float64(totalCount)
+
+	// 如果minSalary没有被更新（仍是初始值），设置为0
+	if minSalary == int(^uint(0)>>1) {
+		minSalary = 0
+	}
+	if minPerPersonSalary == int(^uint(0)>>1) {
+		minPerPersonSalary = 0
+	}
+
+	// 创建或更新统计记录
+	stats := &model.DungeonStats{
+		GuildID:              guildID,
+		DungeonName:          dungeonName,
+		TotalCount:           totalCount,
+		MinSalary:            minSalary,
+		MaxSalary:            maxSalary,
+		AvgSalary:            avgSalary,
+		MinPerPersonSalary:   minPerPersonSalary,
+		MaxPerPersonSalary:   maxPerPersonSalary,
+		AvgPerPersonSalary:   avgPerPersonSalary,
+		MinSalaryTeamID:      minSalaryTeamID,
+		MaxSalaryTeamID:      maxSalaryTeamID,
+	}
+
+	// 使用upsert更新或插入统计数据
+	err = s.dungeonStatsDao.UpsertStatsByTx(ctx, tx, stats)
+	if err != nil {
+		logger.Error("UpsertStatsByTx error", logger.Err(err))
+		return err
+	}
+
+	return nil
+}
+
+// GetStatsByGuildAndDungeon 获取指定公会和副本的统计数据
+func (s *DungeonStatsService) GetStatsByGuildAndDungeon(ctx context.Context, guildID int, dungeonName string) (*model.DungeonStats, error) {
+	stats, err := s.dungeonStatsDao.GetByGuildAndDungeon(ctx, guildID, dungeonName)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// 如果统计数据不存在，尝试生成
+			err = s.UpdateStatsForTeam(ctx, guildID, dungeonName)
+			if err != nil {
+				return nil, err
+			}
+			// 重新获取
+			return s.dungeonStatsDao.GetByGuildAndDungeon(ctx, guildID, dungeonName)
+		}
+		return nil, err
+	}
+	return stats, nil
+}
+
+// GetAllStatsByGuild 获取指定公会的所有副本统计数据
+func (s *DungeonStatsService) GetAllStatsByGuild(ctx context.Context, guildID int) ([]*model.DungeonStats, error) {
+	params := &query.Params{
+		Page:  0,
+		Limit: 1000,
+		Columns: []query.Column{
+			{
+				Name:  "guild_id",
+				Exp:   "=",
+				Value: guildID,
+			},
+		},
+		Sort: "dungeon_name",
+	}
+
+	stats, _, err := s.dungeonStatsDao.GetByColumns(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return stats, nil
+}

--- a/api/team.proto
+++ b/api/team.proto
@@ -213,6 +213,24 @@ service TeamService {
       }
     };
   }
+
+  // 获取副本统计数据
+  rpc GetDungeonStats(GetDungeonStatsRequest) returns (GetDungeonStatsResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/team/getDungeonStats"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "获取副本统计数据"
+      description: "根据公会ID和副本名称获取统计数据"
+      security: {
+        security_requirement: {
+          key: "BearerAuth"
+          value: {}
+        }
+      }
+    };
+  }
 }
 
 // 创建开团请求
@@ -379,4 +397,33 @@ message TemplateInfo {
   string notice = 6;
   string createTime = 7;  // ISO8601 格式
   string updateTime = 8;  // ISO8601 格式
+}
+
+// 获取副本统计数据请求
+message GetDungeonStatsRequest {
+  uint64 guildId = 1;
+  string dungeonName = 2;  // 副本名称，可选。如果为空，返回该公会所有副本的统计
+}
+
+// 获取副本统计数据响应
+message GetDungeonStatsResponse {
+  repeated DungeonStatsInfo stats = 1;
+}
+
+// 副本统计信息
+message DungeonStatsInfo {
+  uint64 id = 1;
+  uint64 guildId = 2;
+  string dungeonName = 3;
+  int32 totalCount = 4;
+  int32 minSalary = 5;
+  int32 maxSalary = 6;
+  double avgSalary = 7;
+  int32 minPerPersonSalary = 8;
+  int32 maxPerPersonSalary = 9;
+  double avgPerPersonSalary = 10;
+  uint64 minSalaryTeamId = 11;
+  uint64 maxSalaryTeamId = 12;
+  string createTime = 13;  // ISO8601 格式
+  string updateTime = 14;  // ISO8601 格式
 }

--- a/sql/add_dungeon_stats.sql
+++ b/sql/add_dungeon_stats.sql
@@ -1,0 +1,48 @@
+-- 副本统计数据表迁移脚本
+-- 用于记录每个公会每个副本类型的统计数据（最大值、最小值等）
+
+BEGIN;
+
+-- 创建副本统计数据表
+CREATE TABLE IF NOT EXISTS dungeon_stats (
+    id SERIAL PRIMARY KEY,  -- 统计ID, 自增主键
+    guild_id INT NOT NULL,  -- 群组ID, 外键
+    dungeon_name VARCHAR(50) NOT NULL,  -- 副本名称
+    total_count INT NOT NULL DEFAULT 0,  -- 总记录数
+    min_salary INT NOT NULL DEFAULT 0,  -- 最低总金团
+    max_salary INT NOT NULL DEFAULT 0,  -- 最高总金团
+    avg_salary DECIMAL(10, 2) NOT NULL DEFAULT 0,  -- 平均总金团
+    min_per_person_salary INT NOT NULL DEFAULT 0,  -- 最低人均金团
+    max_per_person_salary INT NOT NULL DEFAULT 0,  -- 最高人均金团
+    avg_per_person_salary DECIMAL(10, 2) NOT NULL DEFAULT 0,  -- 平均人均金团
+    min_salary_team_id INT,  -- 最低金团对应的团队ID
+    max_salary_team_id INT,  -- 最高金团对应的团队ID
+    create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,  -- 创建时间
+    update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,  -- 更新时间
+    FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE,  -- 外键关联群组表, 级联删除
+    UNIQUE(guild_id, dungeon_name)  -- 确保每个公会的每个副本只有一条统计记录
+);
+
+-- 添加副本统计数据表注释
+COMMENT ON TABLE dungeon_stats IS '副本统计数据表';
+COMMENT ON COLUMN dungeon_stats.id IS '统计ID';
+COMMENT ON COLUMN dungeon_stats.guild_id IS '群组ID';
+COMMENT ON COLUMN dungeon_stats.dungeon_name IS '副本名称';
+COMMENT ON COLUMN dungeon_stats.total_count IS '总记录数';
+COMMENT ON COLUMN dungeon_stats.min_salary IS '最低总金团';
+COMMENT ON COLUMN dungeon_stats.max_salary IS '最高总金团';
+COMMENT ON COLUMN dungeon_stats.avg_salary IS '平均总金团';
+COMMENT ON COLUMN dungeon_stats.min_per_person_salary IS '最低人均金团';
+COMMENT ON COLUMN dungeon_stats.max_per_person_salary IS '最高人均金团';
+COMMENT ON COLUMN dungeon_stats.avg_per_person_salary IS '平均人均金团';
+COMMENT ON COLUMN dungeon_stats.min_salary_team_id IS '最低金团对应的团队ID';
+COMMENT ON COLUMN dungeon_stats.max_salary_team_id IS '最高金团对应的团队ID';
+COMMENT ON COLUMN dungeon_stats.create_time IS '创建时间';
+COMMENT ON COLUMN dungeon_stats.update_time IS '更新时间';
+
+-- 创建副本统计数据表索引
+CREATE INDEX idx_dungeon_stats_guild_id ON dungeon_stats(guild_id);
+CREATE INDEX idx_dungeon_stats_dungeon_name ON dungeon_stats(dungeon_name);
+CREATE INDEX idx_dungeon_stats_guild_dungeon ON dungeon_stats(guild_id, dungeon_name);
+
+COMMIT;


### PR DESCRIPTION
主要改进：
- 新增dungeon_stats表，单独存储每个副本的最大值、最小值和平均值统计数据
- 创建DungeonStatsService服务，在团队关闭/修改时自动更新统计数据
- 新增/api/v1/team/getDungeonStats接口，支持获取副本统计数据
- 前端改为从后端获取统计数据，不再在客户端计算所有记录

技术实现：
- 数据库：新增dungeon_stats表，包含最大值、最小值、平均值等统计字段
- Model层：新增DungeonStats模型
- DAO层：实现dungeonStats的CRUD操作，支持upsert
- Cache层：新增dungeonStats缓存
- Service层：实现统计数据的自动计算和更新逻辑
- Handler层：在CloseTeam和UpdateTeam中异步更新统计数据
- API层：新增GetDungeonStats接口
- 前端：调用新API获取统计数据，优化渲染性能

性能优化：
- 避免前端每次渲染都计算所有记录的最大最小值
- 统计数据在后端维护，前端直接使用
- 为后续实现分页查询打下基础